### PR TITLE
Fix test timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ This is the initial release version. The code has been thoroughly tested with 10
 
 Updates to dependencies to remove security vulnerabilities. Updates to the packaging.
 
-### v1.1.1 - Dependency Updates
+#### Fixes
+
+- v1.1.1 - Dependency Updates
 
 Updated all dependencies to the latest releases. This fixed an vulnerability with Handlebars which was a nested dependency. Handlebars is no longer a nested dependency with this release.
 
@@ -49,6 +51,11 @@ Updated all dependencies to the latest releases. This fixed an vulnerability wit
 - Added a new method to the TaskTimer class that now allows you to define your own current time source. This can be used to provide a more accurate time source than the default `Date.now()`. This change is fully backward compatible.
 - Added a new utility function:
   - `setValue`
+
+#### Fixes
+
+- v1.2.1 - Fix Rest Parameter Handling
+- v1.2.2 - Fix Test Timing Expectations
 
 ## The MIT License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "af-utilities",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Utility functions used within the af-XXXX Frameworks and Libraries",
   "main": "dist/lib/index.js",
   "scripts": {

--- a/test/lib/util/logging.spec.ts
+++ b/test/lib/util/logging.spec.ts
@@ -1,47 +1,46 @@
-import 'mocha';
+import "mocha";
 
-import { expect } from 'chai';
-import sinon from 'sinon';
+import { expect } from "chai";
+import sinon from "sinon";
 
 import {
-    BaseLogger,
-    LOG_SEVERITY_COUNT,
-    LOG_SEVERITY_LOWEST_SEVERITY,
-    LogDriver,
-    Logger,
-    logger,
-    LogSeverity,
-} from '../../../src/lib';
+  BaseLogger,
+  LOG_SEVERITY_COUNT,
+  LOG_SEVERITY_LOWEST_SEVERITY,
+  LogDriver,
+  Logger,
+  logger,
+  LogSeverity,
+} from "../../../src/lib";
 
 // tslint:disable:no-unused-expression no-null-keyword no-console
 
 class TestLogger extends BaseLogger implements LogDriver {
+  public alert = sinon.spy();
+  public critical = sinon.spy();
+  public debug = sinon.spy();
+  public emergency = sinon.spy();
+  public error = sinon.spy();
+  public info = sinon.spy();
+  public log = sinon.spy();
+  public notice = sinon.spy();
+  public time = sinon.spy();
+  public timeEnd = sinon.spy();
+  public warn = sinon.spy();
 
-    public alert = sinon.spy();
-    public critical = sinon.spy();
-    public debug = sinon.spy();
-    public emergency = sinon.spy();
-    public error = sinon.spy();
-    public info = sinon.spy();
-    public log = sinon.spy();
-    public notice = sinon.spy();
-    public time = sinon.spy();
-    public timeEnd = sinon.spy();
-    public warn = sinon.spy();
-
-    public reset() {
-        this.alert.resetHistory();
-        this.critical.resetHistory();
-        this.debug.resetHistory();
-        this.emergency.resetHistory();
-        this.error.resetHistory();
-        this.info.resetHistory();
-        this.log.resetHistory();
-        this.notice.resetHistory();
-        this.time.resetHistory();
-        this.timeEnd.resetHistory();
-        this.warn.resetHistory();
-    }
+  public reset() {
+    this.alert.resetHistory();
+    this.critical.resetHistory();
+    this.debug.resetHistory();
+    this.emergency.resetHistory();
+    this.error.resetHistory();
+    this.info.resetHistory();
+    this.log.resetHistory();
+    this.notice.resetHistory();
+    this.time.resetHistory();
+    this.timeEnd.resetHistory();
+    this.warn.resetHistory();
+  }
 }
 
 const TEST_LOG_ALERT_MESSAGE = `Alert Message (severity: ${LogSeverity.Alert})`;
@@ -57,414 +56,441 @@ const TEST_LOG_WARNING_MESSAGE = `Warning Message (severity: ${LogSeverity.Warni
 type ConsoleSignature = (message: string, ...params: any[]) => void;
 
 class ConsoleTester {
+  protected originalDebug!: ConsoleSignature | undefined;
+  protected originalTime!: ConsoleSignature | undefined;
+  protected originalTimeEnd!: ConsoleSignature | undefined;
+  protected originalWarn!: ConsoleSignature | undefined;
 
-    protected originalDebug!: ConsoleSignature | undefined;
-    protected originalTime!: ConsoleSignature | undefined;
-    protected originalTimeEnd!: ConsoleSignature | undefined;
-    protected originalWarn!: ConsoleSignature | undefined;
+  /**
+   * Creates an instance of ConsoleTester that will setup console to look
+   * like a particular environment and create Sinon Spy's on the intended
+   * methods. Using the testType parameter you can either setup a
+   * particular environment (browser or node) or leave it set to default
+   * which will determine the spies needed based upon what the current
+   * environment provides.
+   *
+   * @author Mike Coakley https://github.com/mcoakley
+   * @date 2018-07-04
+   * @param {("default" | "node" | "browser")} [testType="default"] tell
+   * ConsoleTester what environment you wish to setup
+   * @param {boolean} [browserWithExtras=false] when you aren't testing a Node
+   * environment (either by default or by selection) you can force this class
+   * to inject a console.warn method if this is set to true
+   * @memberof ConsoleTester
+   */
+  constructor(
+    testType: "default" | "node" | "browser" = "default",
+    browserWithExtras = false
+  ) {
+    // These methods are always found on the console object
+    sinon.spy(console, "error");
+    sinon.spy(console, "info");
+    sinon.spy(console, "log");
 
-    /**
-     * Creates an instance of ConsoleTester that will setup console to look
-     * like a particular environment and create Sinon Spy's on the intended
-     * methods. Using the testType parameter you can either setup a
-     * particular environment (browser or node) or leave it set to default
-     * which will determine the spies needed based upon what the current
-     * environment provides.
-     *
-     * @author Mike Coakley https://github.com/mcoakley
-     * @date 2018-07-04
-     * @param {("default" | "node" | "browser")} [testType="default"] tell
-     * ConsoleTester what environment you wish to setup
-     * @param {boolean} [browserWithExtras=false] when you aren't testing a Node
-     * environment (either by default or by selection) you can force this class
-     * to inject a console.warn method if this is set to true
-     * @memberof ConsoleTester
-     */
-    constructor(
-        testType: 'default' | 'node' | 'browser' = 'default',
-        browserWithExtras = false
-    ) {
-        // These methods are always found on the console object
-        sinon.spy(console, 'error');
-        sinon.spy(console, 'info');
-        sinon.spy(console, 'log');
+    let isNode = typeof console.debug !== "undefined";
+    const warningDefined = isNode || typeof console.warn !== "undefined";
+    const timeDefined = isNode || typeof console.time !== "undefined";
+    const timeEndDefined = isNode || typeof console.timeEnd !== "undefined";
 
-        let isNode = typeof console.debug !== 'undefined';
-        const warningDefined = isNode || typeof console.warn !== 'undefined';
-        const timeDefined = isNode || typeof console.time !== 'undefined';
-        const timeEndDefined = isNode || typeof console.timeEnd !== 'undefined';
+    // Now either setup based upon the environment or create a specific one
+    if (testType === "default") {
+      if (isNode) {
+        sinon.spy(console, "debug");
+        sinon.spy(console, "time");
+        sinon.spy(console, "timeEnd");
+        sinon.spy(console, "warn");
+      } else {
+        if (timeDefined) sinon.spy(console, "time");
+        if (timeEndDefined) sinon.spy(console, "timeEnd");
+        if (warningDefined) sinon.spy(console, "warn");
+      }
+    } else {
+      // We aren't default so force isNode
+      isNode = testType === "node";
+      if (isNode) {
+        sinon.spy(console, "debug");
+        sinon.spy(console, "time");
+        sinon.spy(console, "timeEnd");
+        sinon.spy(console, "warn");
+      } else {
+        this.originalDebug = console.debug;
+        console.debug = undefined!; // Force debug to undefined!
 
-        // Now either setup based upon the environment or create a specific one
-        if (testType === 'default') {
-            if (isNode) {
-                sinon.spy(console, 'debug');
-                sinon.spy(console, 'time');
-                sinon.spy(console, 'timeEnd');
-                sinon.spy(console, 'warn');
-            } else {
-                if (timeDefined) sinon.spy(console, 'time');
-                if (timeEndDefined) sinon.spy(console, 'timeEnd');
-                if (warningDefined) sinon.spy(console, 'warn');
-            }
+        if (browserWithExtras) {
+          if (timeDefined) {
+            sinon.spy(console, "time");
+          } else {
+            console.time = sinon.spy();
+          }
+          if (timeEndDefined) {
+            sinon.spy(console, "timeEnd");
+          } else {
+            console.timeEnd = sinon.spy();
+          }
+          if (warningDefined) {
+            sinon.spy(console, "warn");
+          } else {
+            console.warn = sinon.spy();
+          }
         } else {
-            // We aren't default so force isNode
-            isNode = testType === 'node';
-            if (isNode) {
-                sinon.spy(console, 'debug');
-                sinon.spy(console, 'time');
-                sinon.spy(console, 'timeEnd');
-                sinon.spy(console, 'warn');
-            } else {
-                this.originalDebug = console.debug;
-                console.debug = undefined!; // Force debug to undefined!
-
-                if (browserWithExtras) {
-                    if (timeDefined) {
-                        sinon.spy(console, 'time');
-                    } else {
-                        console.time = sinon.spy();
-                    }
-                    if (timeEndDefined) {
-                        sinon.spy(console, 'timeEnd');
-                    } else {
-                        console.timeEnd = sinon.spy();
-                    }
-                    if (warningDefined) {
-                        sinon.spy(console, 'warn');
-                    } else {
-                        console.warn = sinon.spy();
-                    }
-                } else {
-                    this.originalTime = console.time;
-                    console.time = undefined!;
-                    this.originalTimeEnd = console.timeEnd;
-                    console.timeEnd = undefined!;
-                    this.originalWarn = console.warn;
-                    console.warn = undefined!;
-                }
-            }
+          this.originalTime = console.time;
+          console.time = undefined!;
+          this.originalTimeEnd = console.timeEnd;
+          console.timeEnd = undefined!;
+          this.originalWarn = console.warn;
+          console.warn = undefined!;
         }
+      }
+    }
+  }
+
+  public reset() {
+    // @ts-ignore
+    console.error.resetHistory();
+    // @ts-ignore
+    console.info.resetHistory();
+    // @ts-ignore
+    console.log.resetHistory();
+
+    // @ts-ignore
+    if (typeof console.debug !== "undefined") console.debug.resetHistory();
+    // @ts-ignore
+    if (typeof console.time !== "undefined") console.time.resetHistory();
+    // @ts-ignore
+    if (typeof console.timeEnd !== "undefined") console.timeEnd.resetHistory();
+    // @ts-ignore
+    if (typeof console.warn !== "undefined") console.warn.resetHistory();
+  }
+
+  public restore() {
+    // @ts-ignore
+    console.error.restore();
+    // @ts-ignore
+    console.info.restore();
+    // @ts-ignore
+    console.log.restore();
+
+    if (typeof console.debug !== "undefined") {
+      // @ts-ignore
+      if (typeof console.debug.restore !== "undefined") {
+        // @ts-ignore
+        console.debug.restore();
+      }
+      if (this.originalDebug) {
+        console.debug = this.originalDebug;
+      }
+      this.originalDebug = undefined!;
+    }
+    if (typeof console.time !== "undefined") {
+      // @ts-ignore
+      if (typeof console.time.restore !== "undefined") {
+        // @ts-ignore
+        console.time.restore();
+      }
+      if (this.originalTime) {
+        console.time = this.originalTime;
+      }
+      this.originalTime = undefined!;
+    }
+    if (typeof console.timeEnd !== "undefined") {
+      // @ts-ignore
+      if (typeof console.timeEnd.restore !== "undefined") {
+        // @ts-ignore
+        console.timeEnd.restore();
+      }
+      if (this.originalTimeEnd) {
+        console.timeEnd = this.originalTimeEnd;
+      }
+      this.originalTimeEnd = undefined!;
+    }
+    if (typeof console.warn !== "undefined") {
+      // @ts-ignore
+      if (typeof console.warn.restore !== "undefined") {
+        // @ts-ignore
+        console.warn.restore();
+      }
+      if (this.originalWarn) {
+        console.warn = this.originalWarn;
+      }
+      this.originalWarn = undefined!;
+    }
+  }
+
+  public async testTimeSpies() {
+    function timeout(ms: number) {
+      return new Promise((resolve) => setTimeout(resolve, ms));
     }
 
-    public reset() {
-        // @ts-ignore
-        console.error.resetHistory();
-        // @ts-ignore
-        console.info.resetHistory();
-        // @ts-ignore
-        console.log.resetHistory();
+    const TEST_LABEL = "Testing123";
+    const TEST_DELAY = 200;
+    // We use a lesser value for the test timing expected delay. The
+    // setTimeout function does not guarantee exact timing and can be
+    // a little before or after the requested timeout. By taking 97% of
+    // the requested delay we can reasonably expect to have completed in
+    // this time.
+    const TEST_DELAY_EXPECTED = TEST_DELAY * 0.97;
 
-        // @ts-ignore
-        if (typeof console.debug !== 'undefined') console.debug.resetHistory();
-        // @ts-ignore
-        if (typeof console.time !== 'undefined') console.time.resetHistory();
-        // @ts-ignore
-        if (typeof console.timeEnd !== 'undefined') console.timeEnd.resetHistory();
-        // @ts-ignore
-        if (typeof console.warn !== 'undefined') console.warn.resetHistory();
+    // No need to see any output
+    logger.muteLogger = true;
+
+    let taskId = logger.time(TEST_LABEL);
+    // Since we use TaskTimers we will not receive a
+    // label back that we can actually test against as it will
+    // be a UUID to identify the running task with our label as
+    // a description.
+
+    await timeout(TEST_DELAY);
+    let tStop = logger.timeEnd(taskId);
+    expect(tStop).to.be.at.least(TEST_DELAY_EXPECTED);
+
+    // Tests for coverage
+
+    // Use the default label
+    taskId = logger.time();
+    await timeout(TEST_DELAY);
+    tStop = logger.timeEnd(taskId);
+    expect(tStop).to.be.at.least(TEST_DELAY_EXPECTED);
+
+    // Try to stop a timer with the default label (which should be
+    // impossible)
+    tStop = logger.timeEnd();
+    expect(tStop).to.eq(-1);
+  }
+
+  public testSpies() {
+    // We want to ensure they are ALL called
+    logger.severityLevel = LOG_SEVERITY_LOWEST_SEVERITY;
+    this.callLoggers();
+
+    // Test the simple ones...
+    // @ts-ignore
+    expect(console.error.calledOnce).to.be.true;
+    // @ts-ignore
+    expect(console.info.calledOnce).to.be.true;
+
+    // Test console methods that may be spied
+    if (typeof console.debug !== "undefined") {
+      // @ts-ignore
+      expect(console.debug.calledOnce).to.be.true;
+    } else {
+      expect(
+        console.log
+          // @ts-ignore
+          .withArgs(TEST_LOG_DEBUG_MESSAGE).calledOnce
+      ).to.be.true;
+    }
+    if (typeof console.warn !== "undefined") {
+      // @ts-ignore
+      expect(console.warn.calledOnce).to.be.true;
+    } else {
+      expect(
+        console.log
+          // @ts-ignore
+          .withArgs(TEST_LOG_WARNING_MESSAGE).calledOnce
+      ).to.be.true;
     }
 
-    public restore() {
+    // Test console methods that only use console.log (i.e. Emergency
+    // simply calls console.log)
+    expect(
+      console.log
         // @ts-ignore
-        console.error.restore();
+        .withArgs(TEST_LOG_EMERGENCY_MESSAGE).calledOnce
+    ).to.be.true;
+    expect(
+      console.log
         // @ts-ignore
-        console.info.restore();
+        .withArgs(TEST_LOG_ALERT_MESSAGE).calledOnce
+    ).to.be.true;
+    expect(
+      console.log
         // @ts-ignore
-        console.log.restore();
-
-        if (typeof console.debug !== 'undefined') {
-            // @ts-ignore
-            if (typeof console.debug.restore !== 'undefined') {
-                // @ts-ignore
-                console.debug.restore();
-            }
-            if (this.originalDebug) {
-                console.debug = this.originalDebug;
-            }
-            this.originalDebug = undefined!;
-        }
-        if (typeof console.time !== 'undefined') {
-            // @ts-ignore
-            if (typeof console.time.restore !== 'undefined') {
-                // @ts-ignore
-                console.time.restore();
-            }
-            if (this.originalTime) {
-                console.time = this.originalTime;
-            }
-            this.originalTime = undefined!;
-        }
-        if (typeof console.timeEnd !== 'undefined') {
-            // @ts-ignore
-            if (typeof console.timeEnd.restore !== 'undefined') {
-                // @ts-ignore
-                console.timeEnd.restore();
-            }
-            if (this.originalTimeEnd) {
-                console.timeEnd = this.originalTimeEnd;
-            }
-            this.originalTimeEnd = undefined!;
-        }
-        if (typeof console.warn !== 'undefined') {
-            // @ts-ignore
-            if (typeof console.warn.restore !== 'undefined') {
-                // @ts-ignore
-                console.warn.restore();
-            }
-            if (this.originalWarn) {
-                console.warn = this.originalWarn;
-            }
-            this.originalWarn = undefined!;
-        }
-    }
-
-    public async testTimeSpies() {
-
-        function timeout(ms: number) {
-            return new Promise((resolve) => setTimeout(resolve, ms));
-        }
-
-        const TEST_LABEL = 'Testing123';
-        const TEST_DELAY = 200;
-
-        // No need to see any output
-        logger.muteLogger = true;
-
-        let taskId = logger.time(TEST_LABEL);
-        // Since we use TaskTimers we will not receive a
-        // label back that we can actually test against as it will
-        // be a UUID to identify the running task with our label as
-        // a description.
-
-        await timeout(TEST_DELAY);
-        let tStop = logger.timeEnd(taskId);
-        expect(tStop).to.be.at.least(TEST_DELAY);
-
-        // Tests for coverage
-
-        // Use the default label
-        taskId = logger.time();
-        await timeout(TEST_DELAY);
-        tStop = logger.timeEnd(taskId);
-        expect(tStop).to.be.at.least(TEST_DELAY);
-
-        // Try to stop a timer with the default label (which should be
-        // impossible)
-        tStop = logger.timeEnd();
-        expect(tStop).to.eq(-1);
-    }
-
-    public testSpies() {
-        // We want to ensure they are ALL called
-        logger.severityLevel = LOG_SEVERITY_LOWEST_SEVERITY;
-        this.callLoggers();
-
-        // Test the simple ones...
+        .withArgs(TEST_LOG_CRITICAL_MESSAGE).calledOnce
+    ).to.be.true;
+    expect(
+      console.log
         // @ts-ignore
-        expect(console.error.calledOnce).to.be.true;
+        .withArgs(TEST_LOG_NOTICE_MESSAGE).calledOnce
+    ).to.be.true;
+
+    // ...and finally test the log method itself
+    expect(
+      console.log
         // @ts-ignore
-        expect(console.info.calledOnce).to.be.true;
+        .withArgs(TEST_LOG_LOG_MESSAGE).calledOnce
+    ).to.be.true;
+  }
 
-        // Test console methods that may be spied
-        if (typeof console.debug !== 'undefined') {
-            // @ts-ignore
-            expect(console.debug.calledOnce).to.be.true;
-        } else {
-            expect(console.log
-                // @ts-ignore
-                .withArgs(TEST_LOG_DEBUG_MESSAGE).calledOnce).to.be.true;
-        }
-        if (typeof console.warn !== 'undefined') {
-            // @ts-ignore
-            expect(console.warn.calledOnce).to.be.true;
-        } else {
-            expect(console.log
-                // @ts-ignore
-                .withArgs(TEST_LOG_WARNING_MESSAGE).calledOnce).to.be.true;
-        }
+  public testSeverity(severityLevel: LogSeverity) {
+    logger.severityLevel = severityLevel;
+    this.callLoggers();
 
-        // Test console methods that only use console.log (i.e. Emergency
-        // simply calls console.log)
-        expect(console.log
-            // @ts-ignore
-            .withArgs(TEST_LOG_EMERGENCY_MESSAGE).calledOnce).to.be.true;
-        expect(console.log
-            // @ts-ignore
-            .withArgs(TEST_LOG_ALERT_MESSAGE).calledOnce).to.be.true;
-        expect(console.log
-            // @ts-ignore
-            .withArgs(TEST_LOG_CRITICAL_MESSAGE).calledOnce).to.be.true;
-        expect(console.log
-            // @ts-ignore
-            .withArgs(TEST_LOG_NOTICE_MESSAGE).calledOnce).to.be.true;
+    // NOTE: We add 1 because LogSeverity.Informational is used for both
+    //       calls to logger.info and logger.log
+    const logSeverities = LOG_SEVERITY_COUNT + 1;
+    const filteredCount =
+      logSeverities -
+      (severityLevel +
+        1 +
+        (severityLevel >= LogSeverity.Informational ? 1 : 0));
+    const loggedCount = logSeverities - filteredCount;
 
-        // ...and finally test the log method itself
-        expect(console.log.
-            // @ts-ignore
-            withArgs(TEST_LOG_LOG_MESSAGE).calledOnce).to.be.true;
-    }
+    expect(logger.filteredMessages).to.eq(filteredCount);
+    expect(logger.messagesLogged).to.eq(loggedCount);
+  }
 
-    public testSeverity(severityLevel: LogSeverity) {
-        logger.severityLevel = severityLevel;
-        this.callLoggers();
-
-        // NOTE: We add 1 because LogSeverity.Informational is used for both
-        //       calls to logger.info and logger.log
-        const logSeverities = LOG_SEVERITY_COUNT + 1;
-        const filteredCount = logSeverities - (severityLevel + 1 +
-            (severityLevel >= LogSeverity.Informational ? 1 : 0));
-        const loggedCount = logSeverities - filteredCount;
-
-        expect(logger.filteredMessages).to.eq(filteredCount);
-        expect(logger.messagesLogged).to.eq(loggedCount);
-    }
-
-    protected callLoggers() {
-        logger.alert(TEST_LOG_ALERT_MESSAGE);
-        logger.critical(TEST_LOG_CRITICAL_MESSAGE);
-        logger.debug(TEST_LOG_DEBUG_MESSAGE);
-        logger.emergency(TEST_LOG_EMERGENCY_MESSAGE);
-        logger.error(TEST_LOG_ERROR_MESSAGE);
-        logger.info(TEST_LOG_INFORMATIONAL_MESSAGE);
-        logger.log(TEST_LOG_LOG_MESSAGE);
-        logger.notice(TEST_LOG_NOTICE_MESSAGE);
-        logger.warn(TEST_LOG_WARNING_MESSAGE);
-    }
+  protected callLoggers() {
+    logger.alert(TEST_LOG_ALERT_MESSAGE);
+    logger.critical(TEST_LOG_CRITICAL_MESSAGE);
+    logger.debug(TEST_LOG_DEBUG_MESSAGE);
+    logger.emergency(TEST_LOG_EMERGENCY_MESSAGE);
+    logger.error(TEST_LOG_ERROR_MESSAGE);
+    logger.info(TEST_LOG_INFORMATIONAL_MESSAGE);
+    logger.log(TEST_LOG_LOG_MESSAGE);
+    logger.notice(TEST_LOG_NOTICE_MESSAGE);
+    logger.warn(TEST_LOG_WARNING_MESSAGE);
+  }
 }
 
-describe('Logger class', function() {
+describe("Logger class", function () {
+  describe('Testing of the Logger class using a "spied" Logger', function () {
+    const testLogger = new TestLogger();
 
-    describe('Testing of the Logger class using a "spied" Logger', function() {
-
-        const testLogger = new TestLogger();
-
-        before(function() {
-            logger.setLogger(testLogger);
-        });
-
-        after(function() {
-            // Set our logger back to using the default loggers
-            logger.setLogger();
-        });
-
-        describe('Ensures that the module constants are properly defined', function() {
-            it('Validates the LOG_SEVERITY_COUNT constant', function() {
-                expect(Object.keys(LogSeverity).length / 2).to.eq(LOG_SEVERITY_COUNT);
-            });
-
-            it('Validates the LOG_SEVERITY_LOWEST_SEVERITY constant', function() {
-                expect(LogSeverity[LOG_SEVERITY_COUNT - 1]).to.eq(LogSeverity[LOG_SEVERITY_LOWEST_SEVERITY]);
-            });
-        });
-
-        describe('Initialize the Logger class', function() {
-            it('initializes the Logger with the defaults', function() {
-                expect(logger).to.be.an.instanceof(Logger);
-            });
-        });
+    before(function () {
+      logger.setLogger(testLogger);
     });
 
-    describe('Testing of the Logger class using the native Loggers (Browser/Node)', function() {
-
-        beforeEach(function() {
-            logger.reset();
-        });
-
-        type TestType = 'default' | 'node' | 'browser';
-        interface TestProfile {
-            name: string;
-            testType: TestType;
-            browserWithWarn: boolean;
-        }
-
-        const testProfiles: TestProfile[] = [
-            { name: 'NodeLogger', testType: 'node', browserWithWarn: false },
-            { name: 'BrowserLogger', testType: 'browser', browserWithWarn: false },
-            { name: 'BrowserLogger', testType: 'browser', browserWithWarn: true },
-        ];
-
-        testProfiles.forEach((value: TestProfile) => {
-            const testTitleSuffix = value.testType === 'browser' ?
-                ` (w/browserWithWarn = ${value.browserWithWarn})` :
-                '';
-            const testTitle = `${value.name}${testTitleSuffix}`;
-            describe(`Tests using the ${testTitle} class`, function() {
-                let consoleTester: ConsoleTester;
-
-                before(function() {
-                    consoleTester = new ConsoleTester(value.testType, value.browserWithWarn);
-                    logger.setLogger();
-                });
-
-                after(function() {
-                    consoleTester.restore();
-                    logger.reset();
-                    logger.setLogger();
-                });
-
-                describe('Checks that all of the Loggers are called correctly', function() {
-                    it('ensures all Logger logging methods are called', function() {
-                        consoleTester.testSpies();
-                        consoleTester.reset();
-                    });
-                });
-
-                describe('Checks the logging routines with each LogSeverity', function() {
-                    for (const lsKey in LogSeverity) {
-                        if (parseInt(lsKey, 10) >= 0) {
-                            const numLogSeverity = parseInt(lsKey, 10);
-                            it(`Tests LogSeverity (${numLogSeverity})`, function() {
-                                consoleTester.testSeverity(numLogSeverity);
-                                consoleTester.reset();
-                            });
-                        }
-                    }
-                });
-
-                describe('Covers the time/timeEnd workflow', function() {
-                    it('exercises the time/timeEnd workflow', async function() {
-                        await consoleTester.testTimeSpies();
-                        consoleTester.reset();
-                    });
-                });
-
-                describe('Covers non-standard calling patterns', function() {
-                    it('works through the muteLogger workflow', function() {
-                        // Set our baseline
-                        expect(logger.muteLogger).to.be.false;
-                        expect(logger.messagesLogged).to.eq(0);
-                        expect(logger.filteredMessages).to.eq(0);
-
-                        logger.emergency('Test message that should be logged');
-                        expect(logger.messagesLogged).to.eq(1);
-                        expect(logger.filteredMessages).to.eq(0);
-
-                        logger.muteLogger = true;
-                        logger.emergency('Test message that should not be logged');
-                        expect(logger.muteLogger).to.be.true;
-                        expect(logger.messagesLogged).to.eq(1);
-                        expect(logger.filteredMessages).to.eq(1);
-                    });
-
-                    it('works through the severityLevel workflow', function() {
-                        logger.severityLevel = LogSeverity.Emergency;
-                        expect(logger.severityLevel).to.equal(LogSeverity.Emergency);
-
-                        logger.severityLevel = LogSeverity.Debug;
-                        expect(logger.severityLevel).to.equal(LogSeverity.Debug);
-                    });
-
-                    it('ensures that logger.emergency messages can be filtered' +
-                        ' with muteLogger set to true', function() {
-                            logger.muteLogger = true;
-                            expect(logger.messagesLogged).to.eq(0);
-                            expect(logger.filteredMessages).to.eq(0);
-                            logger.emergency('This will not be logged');
-                            expect(logger.messagesLogged).to.eq(0);
-                            expect(logger.filteredMessages).to.eq(1);
-                        });
-                });
-            });
-        });
+    after(function () {
+      // Set our logger back to using the default loggers
+      logger.setLogger();
     });
+
+    describe("Ensures that the module constants are properly defined", function () {
+      it("Validates the LOG_SEVERITY_COUNT constant", function () {
+        expect(Object.keys(LogSeverity).length / 2).to.eq(LOG_SEVERITY_COUNT);
+      });
+
+      it("Validates the LOG_SEVERITY_LOWEST_SEVERITY constant", function () {
+        expect(LogSeverity[LOG_SEVERITY_COUNT - 1]).to.eq(
+          LogSeverity[LOG_SEVERITY_LOWEST_SEVERITY]
+        );
+      });
+    });
+
+    describe("Initialize the Logger class", function () {
+      it("initializes the Logger with the defaults", function () {
+        expect(logger).to.be.an.instanceof(Logger);
+      });
+    });
+  });
+
+  describe("Testing of the Logger class using the native Loggers (Browser/Node)", function () {
+    beforeEach(function () {
+      logger.reset();
+    });
+
+    type TestType = "default" | "node" | "browser";
+    interface TestProfile {
+      name: string;
+      testType: TestType;
+      browserWithWarn: boolean;
+    }
+
+    const testProfiles: TestProfile[] = [
+      { name: "NodeLogger", testType: "node", browserWithWarn: false },
+      { name: "BrowserLogger", testType: "browser", browserWithWarn: false },
+      { name: "BrowserLogger", testType: "browser", browserWithWarn: true },
+    ];
+
+    testProfiles.forEach((value: TestProfile) => {
+      const testTitleSuffix =
+        value.testType === "browser"
+          ? ` (w/browserWithWarn = ${value.browserWithWarn})`
+          : "";
+      const testTitle = `${value.name}${testTitleSuffix}`;
+      describe(`Tests using the ${testTitle} class`, function () {
+        let consoleTester: ConsoleTester;
+
+        before(function () {
+          consoleTester = new ConsoleTester(
+            value.testType,
+            value.browserWithWarn
+          );
+          logger.setLogger();
+        });
+
+        after(function () {
+          consoleTester.restore();
+          logger.reset();
+          logger.setLogger();
+        });
+
+        describe("Checks that all of the Loggers are called correctly", function () {
+          it("ensures all Logger logging methods are called", function () {
+            consoleTester.testSpies();
+            consoleTester.reset();
+          });
+        });
+
+        describe("Checks the logging routines with each LogSeverity", function () {
+          for (const lsKey in LogSeverity) {
+            if (parseInt(lsKey, 10) >= 0) {
+              const numLogSeverity = parseInt(lsKey, 10);
+              it(`Tests LogSeverity (${numLogSeverity})`, function () {
+                consoleTester.testSeverity(numLogSeverity);
+                consoleTester.reset();
+              });
+            }
+          }
+        });
+
+        describe("Covers the time/timeEnd workflow", function () {
+          it("exercises the time/timeEnd workflow", async function () {
+            await consoleTester.testTimeSpies();
+            consoleTester.reset();
+          });
+        });
+
+        describe("Covers non-standard calling patterns", function () {
+          it("works through the muteLogger workflow", function () {
+            // Set our baseline
+            expect(logger.muteLogger).to.be.false;
+            expect(logger.messagesLogged).to.eq(0);
+            expect(logger.filteredMessages).to.eq(0);
+
+            logger.emergency("Test message that should be logged");
+            expect(logger.messagesLogged).to.eq(1);
+            expect(logger.filteredMessages).to.eq(0);
+
+            logger.muteLogger = true;
+            logger.emergency("Test message that should not be logged");
+            expect(logger.muteLogger).to.be.true;
+            expect(logger.messagesLogged).to.eq(1);
+            expect(logger.filteredMessages).to.eq(1);
+          });
+
+          it("works through the severityLevel workflow", function () {
+            logger.severityLevel = LogSeverity.Emergency;
+            expect(logger.severityLevel).to.equal(LogSeverity.Emergency);
+
+            logger.severityLevel = LogSeverity.Debug;
+            expect(logger.severityLevel).to.equal(LogSeverity.Debug);
+          });
+
+          it(
+            "ensures that logger.emergency messages can be filtered" +
+              " with muteLogger set to true",
+            function () {
+              logger.muteLogger = true;
+              expect(logger.messagesLogged).to.eq(0);
+              expect(logger.filteredMessages).to.eq(0);
+              logger.emergency("This will not be logged");
+              expect(logger.messagesLogged).to.eq(0);
+              expect(logger.filteredMessages).to.eq(1);
+            }
+          );
+        });
+      });
+    });
+  });
 });

--- a/test/lib/util/task-timers.spec.ts
+++ b/test/lib/util/task-timers.spec.ts
@@ -1,107 +1,105 @@
-import 'mocha';
+import "mocha";
 
-import { expect } from 'chai';
+import { expect } from "chai";
 
 import {
-    DEFAULT_TASK_TIMER_MANAGER_NAME,
-    defaultTimers,
-    logger,
-    TaskData,
-    TaskStatus,
-    TaskTimer,
-    TaskTimerReport,
-    UniqueTaskId,
-} from '../../../src/lib';
+  DEFAULT_TASK_TIMER_MANAGER_NAME,
+  defaultTimers,
+  logger,
+  TaskData,
+  TaskStatus,
+  TaskTimer,
+  TaskTimerReport,
+  UniqueTaskId,
+} from "../../../src/lib";
 
 // tslint:disable:no-unused-expression
 
-describe('UniqueTaskId class', function() {
+describe("UniqueTaskId class", function () {
+  it("should get a string taskId", function () {
+    const taskId: string = UniqueTaskId.getTaskId();
+    expect(taskId).to.be.a("string");
+  });
 
-    it('should get a string taskId', function() {
-        const taskId: string = UniqueTaskId.getTaskId();
-        expect(taskId).to.be.a('string');
-    });
+  it("task id's should be different each call", function () {
+    const taskId1: string = UniqueTaskId.getTaskId();
+    const taskId2: string = UniqueTaskId.getTaskId();
 
-    it('task id\'s should be different each call', function() {
-        const taskId1: string = UniqueTaskId.getTaskId();
-        const taskId2: string = UniqueTaskId.getTaskId();
-
-        expect(taskId1).to.not.equal(taskId2);
-    });
-
+    expect(taskId1).to.not.equal(taskId2);
+  });
 });
 
-describe('TaskTimerManager class', function() {
-    const TEST_DELAY = 200;
+describe("TaskTimerManager class", function () {
+  const TEST_DELAY = 200;
+  // Ensure we account for inconsistencies possible in setTimeout
+  const TEST_DEPLAY_EXPECTED = TEST_DELAY * 0.97;
 
-    before(function() {
-        logger.reset(); // Don't assume anything
-        logger.muteLogger = true;
-    });
+  before(function () {
+    logger.reset(); // Don't assume anything
+    logger.muteLogger = true;
+  });
 
-    after(function() {
-        logger.reset();
-    });
+  after(function () {
+    logger.reset();
+  });
 
-    it('start a timer', function() {
-        const taskId: string = defaultTimers.startTimer('Test Timer');
-        expect(taskId).to.be.a('string');
+  it("start a timer", function () {
+    const taskId: string = defaultTimers.startTimer("Test Timer");
+    expect(taskId).to.be.a("string");
 
-        const taskData: TaskData | undefined = defaultTimers.timerStatus(taskId);
-        expect(taskData).to.not.be.undefined;
-        expect(taskData!.status).to.be.equal(TaskStatus.running);
-        expect(taskData!.taskId).to.be.equal(taskId);
-        expect(taskData!.start).to.be.greaterThan(0);
-    });
+    const taskData: TaskData | undefined = defaultTimers.timerStatus(taskId);
+    expect(taskData).to.not.be.undefined;
+    expect(taskData!.status).to.be.equal(TaskStatus.running);
+    expect(taskData!.taskId).to.be.equal(taskId);
+    expect(taskData!.start).to.be.greaterThan(0);
+  });
 
-    it('start, wait (~' + TEST_DELAY + 'ms), and stop a timer', function(done) {
-        let tReport: TaskTimerReport = defaultTimers.timerReport();
-        const currentCount: number = tReport.taskCount;
+  it("start, wait (~" + TEST_DELAY + "ms), and stop a timer", function (done) {
+    let tReport: TaskTimerReport = defaultTimers.timerReport();
+    const currentCount: number = tReport.taskCount;
 
-        const taskId: string = defaultTimers.startTimer('Test Timer');
-        setTimeout(function() {
-            const tStop = defaultTimers.stopTimer(taskId);
-            expect(tStop).to.be.at.least(TEST_DELAY);
+    const taskId: string = defaultTimers.startTimer("Test Timer");
+    setTimeout(function () {
+      const tStop = defaultTimers.stopTimer(taskId);
+      expect(tStop).to.be.at.least(TEST_DEPLAY_EXPECTED);
 
-            tReport = defaultTimers.timerReport();
-            expect(tReport.taskCount).to.equal(currentCount + 1);
-            done();
-        }, TEST_DELAY);
-    });
+      tReport = defaultTimers.timerReport();
+      expect(tReport.taskCount).to.equal(currentCount + 1);
+      done();
+    }, TEST_DELAY);
+  });
 
-    it('stopTimer should return a negative result for an unknown taskId', function() {
-        defaultTimers.startTimer('Test Timer');
-        const tStop: number = defaultTimers.stopTimer('NO WAY');
-        expect(tStop).to.be.lessThan(0);
-    });
+  it("stopTimer should return a negative result for an unknown taskId", function () {
+    defaultTimers.startTimer("Test Timer");
+    const tStop: number = defaultTimers.stopTimer("NO WAY");
+    expect(tStop).to.be.lessThan(0);
+  });
 
-    it('timerStatus should return an undefined result for an unknown taskId', function() {
-        defaultTimers.startTimer('Test Timer');
-        const tStatus: TaskData | undefined = defaultTimers.timerStatus('NO WAY');
-        expect(tStatus).to.be.undefined;
-    });
+  it("timerStatus should return an undefined result for an unknown taskId", function () {
+    defaultTimers.startTimer("Test Timer");
+    const tStatus: TaskData | undefined = defaultTimers.timerStatus("NO WAY");
+    expect(tStatus).to.be.undefined;
+  });
 
-    it('getName() should return the name of the timers', function() {
-        expect(defaultTimers.getName()).to.equal(DEFAULT_TASK_TIMER_MANAGER_NAME);
-    });
+  it("getName() should return the name of the timers", function () {
+    expect(defaultTimers.getName()).to.equal(DEFAULT_TASK_TIMER_MANAGER_NAME);
+  });
 
-    it('toString() should return a string', function() {
-        expect(defaultTimers.toString()).to.be.a('string');
-    });
+  it("toString() should return a string", function () {
+    expect(defaultTimers.toString()).to.be.a("string");
+  });
 });
 
-describe('TaskTimer class', function() {
+describe("TaskTimer class", function () {
+  it("should throw TypeError during construction", function () {
+    expect(function () {
+      // @ts-ignore
+      new TaskTimer(undefined, "Hello");
+    }).to.throw(TypeError);
 
-    it('should throw TypeError during construction', function() {
-        expect(function() {
-            // @ts-ignore
-            new TaskTimer(undefined, 'Hello');
-        }).to.throw(TypeError);
-
-        expect(function() {
-            // @ts-ignore
-            new TaskTimer("This doesn't matter", undefined);
-        }).to.throw(TypeError);
-    });
-
+    expect(function () {
+      // @ts-ignore
+      new TaskTimer("This doesn't matter", undefined);
+    }).to.throw(TypeError);
+  });
 });


### PR DESCRIPTION
Fixes an issue where testing might fail due to `setTimeout` a minimal amount prior to the requested timeout. This is known for `setTimeout`. The tests now take 3% off of the requested delay and ensure that the delay is at least that amount.

> The diff's are large as the formatting changed.