### PR TITLE
Fix typo variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "af-utilities",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Utility functions used within the af-XXXX Frameworks and Libraries",
   "main": "dist/lib/index.js",
   "scripts": {

--- a/test/lib/util/task-timers.spec.ts
+++ b/test/lib/util/task-timers.spec.ts
@@ -32,7 +32,7 @@ describe('UniqueTaskId class', function () {
 describe('TaskTimerManager class', function () {
   const TEST_DELAY = 200;
   // Ensure we account for inconsistencies possible in setTimeout
-  const TEST_DEPLAY_EXPECTED = TEST_DELAY * 0.97;
+  const TEST_DELAY_EXPECTED = TEST_DELAY * 0.97;
 
   before(function () {
     logger.reset(); // Don't assume anything
@@ -61,7 +61,7 @@ describe('TaskTimerManager class', function () {
     const taskId: string = defaultTimers.startTimer('Test Timer');
     setTimeout(function () {
       const tStop = defaultTimers.stopTimer(taskId);
-      expect(tStop).to.be.at.least(TEST_DEPLAY_EXPECTED);
+      expect(tStop).to.be.at.least(TEST_DELAY_EXPECTED);
 
       tReport = defaultTimers.timerReport();
       expect(tReport.taskCount).to.equal(currentCount + 1);


### PR DESCRIPTION
A single variable in `task-timers.spec.ts` was incorrectly typed. This fixes that issue.